### PR TITLE
fix(Ng2SelectModule): Fix webpack bundle to export Ng2SelectModule (#4) (#5)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,2 +1,2 @@
-declare const Ng2Select: any;
-export { Ng2Select };
+declare const Ng2SelectModule: any;
+export { Ng2SelectModule };

--- a/index.ts
+++ b/index.ts
@@ -1,2 +1,2 @@
-const Ng2Select = require('./ng2-select.bundle.js').Ng2Select;
-export {Ng2Select};
+const Ng2SelectModule = require('./ng2-select.bundle.js').Ng2SelectModule;
+export {Ng2SelectModule};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,7 +8,7 @@ var autoprefixer = require('autoprefixer');
 var webpackConfig = {
     entry: {
         'vendor': ['@angular/core', '@angular/common', '@angular/forms'],
-        'ng2-select': './src/ng2-select.ts'
+        'ng2-select': './src/ng2-select.module.ts'
     },
 
     output: {


### PR DESCRIPTION
Hi @Gbuomprisco, I found the bundle bug.

Here is a fix to export the Ng2SelectModule.

I believe it'll fix issues #4 and #5
