### PR TITLE
angular-cli 1.0.0-beta.22 compatible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 /coverage
 index.js
 index.js.map
+
+# Ignore IDE files
+.idea/

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,5 @@
 !dist/ng2-tag-input.bundle.js
 !dist/ng2-tag-input.map
 !index.js
+!src
+!index.ts

--- a/index.ts
+++ b/index.ts
@@ -1,2 +1,2 @@
-export { Ng2SelectModule } from './dist/src/ng2-select.module';
-export { Ng2Select } from './dist/src/ng2-select';
+export { Ng2SelectModule } from './src/ng2-select.module';
+export { Ng2Select } from './src/ng2-select';

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
   "main": "./dist/ng2-select.bundle.js",
   "files": [
     "dist",
-    "index.ts"
+    "index.ts",
+    "src"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Angular 2 material-like Select Component",
   "scripts": {
     "prepublish": "npm run build && ./node_modules/.bin/tsc -p tsconfig.json",
-    "build": "webpack --inline --colors --progress --display-error-details --display-cached",
+    "build": "webpack --colors --progress --display-error-details --display-cached",
     "watch": "npm run build -- --watch",
     "server": "webpack-dev-server --config webpack.demo.js --inline --colors --progress --display-error-details --display-cached --port 3003  --content-base demo",
     "start": "npm run server",
@@ -56,9 +56,9 @@
     "ts-helpers": "1.1.1",
     "ts-node": "^0.7.3",
     "tslint": "^3.5.0",
-    "typescript": "2.0.2",
+    "typescript": "2.0.10",
     "url-loader": "^0.5.7",
-    "webpack": "^1.13.1",
+    "webpack": "2.1.0-beta.25",
     "webpack-dev-server": "^1.14.0",
     "webpack-merge": "^0.8.4",
     "zone.js": "~0.6.23"

--- a/src/accessor.ts
+++ b/src/accessor.ts
@@ -2,7 +2,7 @@ import {
     ControlValueAccessor
 } from '@angular/forms';
 
-const equal = require('equals');
+import * as equal from 'equals';
 
 export class SelectAccessor implements ControlValueAccessor {
     public options: any[];
@@ -30,7 +30,7 @@ export class SelectAccessor implements ControlValueAccessor {
         this._value = value || [];
     }
 
-    public findIndexValue(value): number {
+    public findIndexValue(value): number|void {
         const identifyBy = this.identifyBy;
 
         if (identifyBy) {

--- a/src/decorators/selectable.ts
+++ b/src/decorators/selectable.ts
@@ -1,8 +1,7 @@
-const equal = require('equals');
 
 export function Selectable() {
     return function(target) {
-        const toggle = function(item): void {
+        const toggle = function(this: any, item): void {
             if (this.multiple === false) {
                 return;
             }

--- a/src/ng2-select.ts
+++ b/src/ng2-select.ts
@@ -11,7 +11,7 @@ import { Selectable } from './decorators/selectable';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { Ng2Dropdown } from 'ng2-material-dropdown';
 import { SelectAccessor } from './accessor';
-const equal = require('equals');
+import * as equal from 'equals';
 
 const CUSTOM_SELECT_VALUE_ACCESSOR = {
     provide: NG_VALUE_ACCESSOR,
@@ -26,8 +26,8 @@ const CUSTOM_SELECT_VALUE_ACCESSOR = {
 @Component({
     selector: 'ng2-select',
     providers: [ CUSTOM_SELECT_VALUE_ACCESSOR ],
-    styles: [ require('./style.scss').toString() ],
-    template: require('./template.html')
+    styleUrls: [ './style.scss' ],
+    templateUrl: './template.html'
 })
 @Selectable()
 export class Ng2Select extends SelectAccessor {
@@ -99,7 +99,8 @@ export class Ng2Select extends SelectAccessor {
             }
 
             // focus selected element
-            const index = this.findIndexValue(this.value);
+            const index: number|void = this.findIndexValue(this.value);
+            if (!index) return;
             const item = this.dropdown.menu.items.toArray()[index];
 
             this.dropdown.state.select(item, false);


### PR DESCRIPTION
**DO NOT merge this**, the webpack build does not work.

But I thought this was the best way to show you how I got your project to compile in angular-cli-1.0.0-beta.22-1, which uses TypeScript 2.0.10 and webpack@2.1.0-beta.25.

There are a few TypeScript errors I had to fix.
May main comment, is that I think **findIndexValue** should return -1 on not found, rather than void/undefined. However, I left the empty return to preserve the API.

I removed the require() calls.

Also, if you need a type definition for equals:

Create *src/equals.d.ts*
```ts
declare var equal:EqualStatic;

declare module 'equals' {
  export = equal;
}

type EqualStatic = (a: any, b: any, memos?: any) => boolean;
```

I have no idea what you need to do to migrate your webpack configuration from version 1 to 2.
